### PR TITLE
Colorblind warning decals

### DIFF
--- a/Colorblind/colorblind.sjson
+++ b/Colorblind/colorblind.sjson
@@ -1,0 +1,15 @@
+{
+  Animations = [
+    "_search"
+    [
+      {Name = "BlastWarningDecal"}
+      {
+        Color = { 
+          Red = 1.0 
+          Green = 1.0 
+          Blue = 1.0 
+        }
+      }
+    ]
+  ]
+}

--- a/Colorblind/modfile.txt
+++ b/Colorblind/modfile.txt
@@ -1,1 +1,3 @@
 Import "colorblind.lua"
+To "Game\Animations\Fx.sjson"
+SJSON "colorblind.sjson"


### PR DESCRIPTION
Increase visibility of BlastWarningDecals for people with red-deficiency colorblindness (protanopia). 