### PR TITLE
Made CodexMenu compatible with ModUtil 3.1.1

### DIFF
--- a/CodexMenu/CodexMenu.lua
+++ b/CodexMenu/CodexMenu.lua
@@ -1,4 +1,4 @@
-ModUtil.RegisterMod("CodexMenu")
+ModUtil.Mod.Register("CodexMenu")
 ModUtil.Table.Merge(CodexMenu, {
     BoonData =
     {
@@ -267,7 +267,7 @@ ModUtil.Table.Merge(CodexMenu, {
 if ModUtil ~= nil and PQOL == nil then
     local mod = "CodexMenu"
 
-    ModUtil.WrapBaseFunction( "SetupMap", function(baseFunc)
+    ModUtil.Path.Wrap( "SetupMap", function(baseFunc)
         DebugPrint({Text = "@"..mod.." Loading all god packages!"})
         LoadPackages({Names = {
             "ZeusUpgrade",

--- a/CodexMenu/dialogmanager.lua
+++ b/CodexMenu/dialogmanager.lua
@@ -446,7 +446,7 @@ function CodexMenu.MakeTextLineForced(screen, button)
     end
 end
 
-ModUtil.BaseOverride("ForcePlayTextLines", function (source, textLinesName )
+ModUtil.Path.Override("ForcePlayTextLines", function (source, textLinesName )
     local possibleSets =
 	{
 		"OnUsedTextLineSets", "InteractTextLineSets", "RepeatableTextLineSets", "SuperPriorityPickupTextLineSets",
@@ -475,7 +475,7 @@ ModUtil.BaseOverride("ForcePlayTextLines", function (source, textLinesName )
 	return false
 end, DialogManager)
 
-ModUtil.BaseOverride("PlayTextLines", function (source, textLines, textline)
+ModUtil.Path.Override("PlayTextLines", function (source, textLines, textline)
     if textLines == nil then
 		return
 	end

--- a/CodexMenu/modfile.txt
+++ b/CodexMenu/modfile.txt
@@ -1,5 +1,5 @@
 Import "CodexMenu.lua"
 Import "dialogmanager.lua"
 
-To "Game/Text/en/Helptext.en.sjson"
+To "Game/Text/en/HelpText.en.sjson"
 SJSON "helptext.en.sjson"


### PR DESCRIPTION
Made CodexMenu compatible with ModUtil 3.1.1.

Only mods with ModUtil 3.1.1 compatibility will be able to use this.
Mostly OE for now.